### PR TITLE
Update ACarousel.swift

### DIFF
--- a/Sources/ACarousel/ACarousel.swift
+++ b/Sources/ACarousel/ACarousel.swift
@@ -46,7 +46,7 @@ public struct ACarousel<Data, ID, Content> : View where Data : RandomAccessColle
         .frame(width: proxy.size.width, height: proxy.size.height, alignment: .leading)
         .offset(x: viewModel.offset)
         .gesture(viewModel.dragGesture)
-        .animation(viewModel.offsetAnimation)
+        .animation(viewModel.offsetAnimation, value: viewModel.offset)
         .onReceive(timer: viewModel.timer, perform: viewModel.receiveTimer)
         .onReceiveAppLifeCycle(perform: viewModel.setTimerActive)
     }


### PR DESCRIPTION
fix bug advance animation when use animation in child View.
link internal animation to specific state variable.